### PR TITLE
Remove google fonts

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -26,7 +26,6 @@
 	
 	<!-- CSS & fonts -->
 	<link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl | replace: '//', '/' }}">
-	<link href='https://fonts.googleapis.com/css?family=PT+Sans:400,700|PT+Serif:400,700' rel='stylesheet' type='text/css'>
 
 	<!-- RSS -->
 	<link href="/atom.xml" type="application/atom+xml" rel="alternate" title="ATOM Feed" />

--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -178,7 +178,7 @@ p.table-title {
 
 .newsbyte h4, h4.stat {
     font-size: 18px;
-    font-family: 'PT Serif', serif;
+    font-family: Georgia, 'Times New Roman', Times, serif;
     font-weight: 700;
     @media (max-width: 480px) {
         font-size: 16px;

--- a/_sass/typography.scss
+++ b/_sass/typography.scss
@@ -9,7 +9,7 @@
 }
 
 body {
-	font-family: 'PT Serif', serif;
+	font-family: Georgia, 'Times New Roman', Times, serif;
 	letter-spacing: 0.01em;
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
@@ -27,14 +27,14 @@ h1 {
 	font-size: 2.25em; /* 36px/16px */
 	line-height: 1.3333em; /* 48px/36px */
 	padding: 0.33335em 0; /* 12px/36px * 2 (Use padding instead of margin to maintain proximity with paragraph) */
-    font-family: 'PT Sans', sans-serif;
+    font-family: Arial, Helvetica, sans-serif;
 }
 
 h2 {
 	font-size: 1.5em; /* 24px/16px */
 	line-height: 1.5em; /* 24px/24px */
 	padding: 1em 0 0 0; /* 12px/24px * 2, only top (Use padding instead of margin to maintain proximity with paragwithph) */
-    font-family: 'PT Sans', sans-serif;
+    font-family: Arial, Helvetica, sans-serif;
     @media (max-width: 480px) {
         font-size: 1.6rem;
     }
@@ -44,7 +44,7 @@ h3 {
     font-size: 1.3em; /* 18px/16px */
     line-height: 1.7em; /* 24px/18px */
 	padding: 0.66667em 0; /* 12px/18px * 2 (Use padding instead of margin to maintain proximity with paragraph) */
-    font-family: 'PT Sans', sans-serif;
+    font-family: Arial, Helvetica, sans-serif;
 }
 
 .hted-head th {
@@ -55,7 +55,7 @@ h4, h5, h6 {
 	font-size: 1.125em; /* 18px/16px */
 	line-height: 1.7em; /* 24px/18px */
 	padding: 0.66667em 0; /* 12px/18px * 2 (Use padding instead of margin to maintain proximity with paragraph) */
-    font-family: 'PT Sans', sans-serif;
+    font-family: Arial, Helvetica, sans-serif;
 }
 
 h5 {


### PR DESCRIPTION
Replaces Google fonts (these add to webpage bloat and are bad for privacy) with fast, built in fonts.  Please test out by pulling branch, clearing cache and comparing to current live site.