### PR TITLE
posts: fix XMR address background

### DIFF
--- a/_sass/custom.scss
+++ b/_sass/custom.scss
@@ -232,7 +232,7 @@ img#veracrypt {
 
 p.address {
     background-color: var(--block-bg-color);
-    color: var(--primary-color);
+    color: var(--link-color);
     font-weight: bold;
     word-wrap: break-word;
     padding: 1.5rem;


### PR DESCRIPTION
Closes #18 

> Note: Donate XMR subaddress should have the same color as hyperlinks, to preserve color cohesion. Contained in this tag each issue file, for what it is worth.