### PR TITLE
Design Fixes #3

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -102,7 +102,8 @@ a {
 	color: var(--head-nav-text-color);
 }
 
-time.by-line {
+time.by-line,
+p.by-line-post {
 	color: var(--table-color);
 }
 


### PR DESCRIPTION
Fixes #21.

### Part 1

Date in periodicals is now more opaque:

<img width="346" alt="image" src="https://user-images.githubusercontent.com/32395585/173411644-47333f47-2adf-41dc-ac3a-b964253ae773.png">

### Part 2

Divider is now more visible in light mode:

<img width="422" alt="image" src="https://user-images.githubusercontent.com/32395585/173411981-3a216bb2-ddb4-49a6-b562-01a6cce164df.png">


and dark mode:

<img width="282" alt="image" src="https://user-images.githubusercontent.com/32395585/173412066-2a1cf6d1-434d-427a-9407-4f5ba2df6cf2.png">

### Part 3

Not sure what's to improve here. Here's the layout on mobile:

<img width="566" alt="image" src="https://user-images.githubusercontent.com/32395585/173412706-dc97bb83-fe80-4c59-885c-5d2b4e4b5c7c.png">

and this is it on desktop:

<img width="779" alt="image" src="https://user-images.githubusercontent.com/32395585/173412748-d17a00c0-8487-435f-9907-d54c3ba898e2.png">

Both layouts look fine to me. The larger gap on the top is a visual indicator, not sure if removing it is a good idea. Do let me know if I missed something!
